### PR TITLE
Fix initialization to use MSRA init

### DIFF
--- a/pytorch/utils.py
+++ b/pytorch/utils.py
@@ -13,15 +13,14 @@ def cast(params, dtype='float'):
         return {k: cast(v, dtype) for k,v in params.items()}
     else:
         return getattr(params.cuda(), dtype)()
-        
 
 def conv_params(ni,no,k=1,g=1):
     assert ni % g == 0
-    return cast(torch.Tensor(no,ni/g,k,k).normal_(0,2/math.sqrt(ni*k*k)))
+    return cast(torch.Tensor(no,ni/g,k,k).normal_(0,math.sqrt(2./(ni*k*k))))
 
 def linear_params(ni,no):
     return cast(dict(
-        weight=torch.Tensor(no,ni).normal_(0,2/math.sqrt(ni)),
+        weight=torch.Tensor(no,ni).normal_(0,math.sqrt(2./ni)),
         bias=torch.zeros(no)))
 
 def bnparams(n):


### PR DESCRIPTION
I believe the stddev of the initialized weights is a factor of sqrt(2) too high in the current Pytorch implementation.

For comparison, the current Lua Torch implementation uses sqrt(2) rather than 2 in the numerator, which is what I would expect from He/MSRA initialization, since Var = 2 / fan_in. https://github.com/szagoruyko/wide-residual-networks/blob/master/models/utils.lua#L6

Does this seem right to you? I unfortunately don't have the time or resources to re-run the code right now. 